### PR TITLE
Fix inject decorator

### DIFF
--- a/tests/e2e/load-env.spec.ts
+++ b/tests/e2e/load-env.spec.ts
@@ -19,6 +19,11 @@ describe('Environment variables', () => {
     expect(envVars.PORT).toEqual('4000');
   });
 
+  it(`should inject env variable with @InjectConfig`, () => {
+    const port = app.get(AppModule).getServerPort();
+    expect(port).toEqual('4000');
+  });
+
   afterEach(async () => {
     await app.close();
   });

--- a/tests/src/app.module.ts
+++ b/tests/src/app.module.ts
@@ -13,6 +13,9 @@ export class AppModule {
     @Optional()
     @InjectConfig('database')
     private readonly databaseConfig: Record<string, any>,
+    @Optional()
+    @InjectConfig('PORT')
+    private readonly serverPort: string,
   ) {}
 
   static withEnvVars(): DynamicModule {
@@ -71,5 +74,9 @@ export class AppModule {
 
   getDatabaseConfig() {
     return this.databaseConfig;
+  }
+
+  getServerPort() {
+    return this.serverPort;
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Using InjectConfig decorator to inject config variable from .env file is not working.

For example, I have an .env file with a config variable:
```
TEST_CONF=123456
```

And using InjectConfig on my service class:
```
export class MyService {
  constructor(
    @InjectConfig('TEST_CONF')
    private readonly testConf: string
  ) {}
}
```

But the testConf is not injected with the value of TEST_CONF from .env file.

Issue Number: 1


## What is the new behavior?

The testConf can be injected with the value of TEST_CONF from .env file correctly.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information