### PR TITLE
Bugfix: Loaded config token names (dot separated)

### DIFF
--- a/lib/utils/merge-configs.util.ts
+++ b/lib/utils/merge-configs.util.ts
@@ -1,10 +1,14 @@
+import set from 'lodash.set';
+
 export function mergeConfigObject(
   host: Record<string, any>,
   partial: Record<string, any>,
   token?: string,
 ) {
   if (token) {
-    return (host[token] = partial);
+    set(host, token, partial);
+
+    return partial;
   }
   Object.assign(host, partial);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -719,6 +719,15 @@
         "@types/lodash": "*"
       }
     },
+    "@types/lodash.set": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.set/-/lodash.set-4.3.6.tgz",
+      "integrity": "sha512-ZeGDDlnRYTvS31Laij0RsSaguIUSBTYIlJFKL3vm3T2OAZAQj2YpSvVWJc0WiG4jqg9fGX6PAPGvDqBcHfSgFg==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -5046,6 +5055,11 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "dotenv": "8.2.0",
     "lodash.get": "4.4.2",
+    "lodash.set": "^4.3.2",
     "uuid": "3.3.3"
   },
   "devDependencies": {
@@ -28,6 +29,7 @@
     "@types/hapi__joi": "16.0.5",
     "@types/jest": "24.0.25",
     "@types/lodash.get": "4.4.6",
+    "@types/lodash.set": "^4.3.6",
     "@types/node": "7.10.8",
     "@types/uuid": "3.4.6",
     "husky": "3.1.0",

--- a/tests/e2e/load-nested-files.spec.ts
+++ b/tests/e2e/load-nested-files.spec.ts
@@ -1,0 +1,25 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { AppModule } from '../src/app.module';
+
+describe('Nested Files', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppModule.withNestedLoadedConfigurations()],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  it(`should return nested loaded configuration`, () => {
+    const host = app.get(AppModule).getNestedDatabaseHost();
+    expect(host).toEqual('host');
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});

--- a/tests/src/app.module.ts
+++ b/tests/src/app.module.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import { ConfigModule } from '../../lib/config.module';
 import { ConfigService } from '../../lib/config.service';
 import databaseConfig from './database.config';
+import nestedDatabaseConfig from './nested-database.config';
 
 @Module({})
 export class AppModule {
@@ -26,6 +27,17 @@ export class AppModule {
       imports: [
         ConfigModule.forRoot({
           load: [databaseConfig],
+        }),
+      ],
+    };
+  }
+
+  static withNestedLoadedConfigurations(): DynamicModule {
+    return {
+      module: AppModule,
+      imports: [
+        ConfigModule.forRoot({
+          load: [nestedDatabaseConfig],
         }),
       ],
     };
@@ -61,5 +73,9 @@ export class AppModule {
 
   getDatabaseHost() {
     return this.configService.get('database.host');
+  }
+
+  getNestedDatabaseHost() {
+    return this.configService.get('database.driver.host');
   }
 }

--- a/tests/src/nested-database.config.ts
+++ b/tests/src/nested-database.config.ts
@@ -1,0 +1,6 @@
+import { registerAs } from '../../lib/utils';
+
+export default registerAs('database.driver', () => ({
+  host: 'host',
+  port: 4000,
+}));


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

This failed:

```ts
export default registerAs('database.mongo', () => ({
  host: 'host',
  port: 4000,
}));

// and then...
this.configService.get('database.mongo.host'); // returns undefined
```

## What is the new behavior?

This doesn't fail & works as intended

```ts
export default registerAs('database.mongo', () => ({
  host: 'host',
  port: 4000,
}));

// and then...
this.configService.get('database.mongo.host'); // returns 'host'
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

It was only fair to use lodash for setting the value when we were using it to get it as well. 😄 