### PR TITLE
Add a overload to ConfigService.get so that it will not returns undefined when defaultValue is provided

### DIFF
--- a/lib/config.service.ts
+++ b/lib/config.service.ts
@@ -18,6 +18,8 @@ export class ConfigService {
    * @param propertyPath
    * @param defaultValue
    */
+  get<T = any>(propertyPath: string): T | undefined;
+  get<T = any>(propertyPath: string, defaultValue: T): T;
   get<T = any>(propertyPath: string, defaultValue?: T): T | undefined {
     const processValue = get(process.env, propertyPath);
     if (!isUndefined(processValue)) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When provided a `defaultValue`, `ConfigService.get` still returns `T | undefined`, which leads to unnecessary error in strict mode of Typescript.
Issue Number: N/A


## What is the new behavior?
When provided a `defaultValue`, `ConfigService.get`returns `T`.
When `defaultValue` is not provided, `ConfigService.get`returns `T | undefined`, as before.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information