### PR TITLE
fix: consistent config values with schema validation

### DIFF
--- a/lib/config.module.ts
+++ b/lib/config.module.ts
@@ -43,8 +43,8 @@ export class ConfigModule {
         let config = this.loadEnvFile(options);
         if (!options.ignoreEnvVars) {
           config = {
-            ...process.env,
             ...config,
+            ...process.env,
           };
         }
         const validationOptions = this.getSchemaValidationOptions(options);
@@ -65,12 +65,12 @@ export class ConfigModule {
     }
     const isConfigToLoad = options.load && options.load.length;
     const providers = (options.load || [])
-      .map(factory =>
+      .map((factory) =>
         createConfigProvider(factory as ConfigFactory & ConfigFactoryKeyHost),
       )
-      .filter(item => item) as FactoryProvider[];
+      .filter((item) => item) as FactoryProvider[];
 
-    const configProviderTokens = providers.map(item => item.provide);
+    const configProviderTokens = providers.map((item) => item.provide);
     const configServiceProvider = {
       provide: ConfigService,
       useFactory: (configService: ConfigService) => configService,
@@ -173,8 +173,8 @@ export class ConfigModule {
     if (!isObject(config)) {
       return;
     }
-    const keys = Object.keys(config).filter(key => !(key in process.env));
-    keys.forEach(key => (process.env[key] = config[key]));
+    const keys = Object.keys(config).filter((key) => !(key in process.env));
+    keys.forEach((key) => (process.env[key] = config[key]));
   }
 
   private static mergePartial(

--- a/tests/e2e/load-priority.spec.ts
+++ b/tests/e2e/load-priority.spec.ts
@@ -1,0 +1,71 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { join } from 'path';
+import { ConfigService } from '../../lib';
+import { AppModule } from '../src/app.module';
+
+describe('Environment variables and .env files', () => {
+  let app: INestApplication;
+  let envBackup: NodeJS.ProcessEnv;
+  beforeAll(() => {
+    envBackup = process.env;
+  });
+  describe('without conflicts', () => {
+    beforeAll(async () => {
+      process.env['NAME'] = 'TEST';
+      const module = await Test.createTestingModule({
+        imports: [AppModule.withEnvVars()],
+      }).compile();
+
+      app = module.createNestApplication();
+      await app.init();
+    });
+
+    it(`should return loaded env variables from vars and dotenv`, () => {
+      const configService = app.get(ConfigService);
+      expect(configService.get('PORT')).toEqual('4000');
+      expect(configService.get('NAME')).toEqual('TEST');
+    });
+  });
+
+  describe('with conflicts', () => {
+    beforeAll(async () => {
+      process.env['PORT'] = '8000';
+      const module = await Test.createTestingModule({
+        imports: [AppModule.withEnvVars()],
+      }).compile();
+
+      app = module.createNestApplication();
+      await app.init();
+    });
+
+    it('should choose env var over dotenv', () => {
+      const configService = app.get(ConfigService);
+      expect(configService.get('PORT')).toEqual('8000');
+    });
+  });
+
+  describe('with conflicts and schema validation', () => {
+    beforeAll(async () => {
+      process.env['PORT'] = '8000';
+      const module = await Test.createTestingModule({
+        imports: [
+          AppModule.withSchemaValidation(join(__dirname, '.env.valid')),
+        ],
+      }).compile();
+
+      app = module.createNestApplication();
+      await app.init();
+    });
+
+    it('should choose env var over dotenv', () => {
+      const configService = app.get(ConfigService);
+      expect(configService.get('PORT')).toEqual(8000);
+    });
+  });
+
+  afterEach(async () => {
+    process.env = envBackup;
+    await app.close();
+  });
+});


### PR DESCRIPTION
## PR Type
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: 168


## What is the new behavior?
Values returned from `ConfigService` should prioritize environment variables over dotenv files when using schemaValidation like it does when not using schemaValidation.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

