### PR TITLE
fix: fixes the infer bug of `ConfigService.get`

### DIFF
--- a/lib/config.service.ts
+++ b/lib/config.service.ts
@@ -5,6 +5,7 @@ import {
   CONFIGURATION_TOKEN,
   VALIDATED_ENV_PROPNAME,
 } from './config.constants';
+import { NoInferType } from './types';
 
 @Injectable()
 export class ConfigService {
@@ -29,7 +30,7 @@ export class ConfigService {
    * @param propertyPath
    * @param defaultValue
    */
-  get<T = any>(propertyPath: string, defaultValue: T): T;
+  get<T = any>(propertyPath: string, defaultValue: NoInferType<T>): T;
   /**
    * Get a configuration value (either custom configuration or process environment variable)
    * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,1 +1,2 @@
 export * from './config.type';
+export * from './no-infer.type';

--- a/lib/types/no-infer.type.ts
+++ b/lib/types/no-infer.type.ts
@@ -1,0 +1,1 @@
+export type NoInferType<T> = [T][T extends any ? 0 : never];


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

When calling `ConfigService.get(propertyPath, defaultValue)`, TypeScript will incorrectly infered the type of `defaultValue` as the return type if the generic was omitted.

```typescript
const value: string = this.configService.get('database.host', 'localhost');
```

Will be infered as:

```typescript
const value: string = this.configService.get<'localhost'>('database.host', 'localhost');
```

## What is the new behavior?

```typescript
const value: string = this.configService.get('database.host', 'localhost');
```

Will be infered as:

```typescript
const value: string = this.configService.get<string>('database.host', 'localhost');
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information