### PR TITLE
feat(config): add optional generic type to config service

### DIFF
--- a/lib/config.service.ts
+++ b/lib/config.service.ts
@@ -8,7 +8,7 @@ import {
 import { NoInferType } from './types';
 
 @Injectable()
-export class ConfigService {
+export class ConfigService<K = any> {
   constructor(
     @Optional()
     @Inject(CONFIGURATION_TOKEN)
@@ -22,7 +22,7 @@ export class ConfigService {
    * @param propertyPath
    * @param defaultValue
    */
-  get<T = any>(propertyPath: string): T | undefined;
+  get<T = any>(propertyPath: keyof K): T | undefined;
   /**
    * Get a configuration value (either custom configuration or process environment variable)
    * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").
@@ -30,7 +30,7 @@ export class ConfigService {
    * @param propertyPath
    * @param defaultValue
    */
-  get<T = any>(propertyPath: string, defaultValue: NoInferType<T>): T;
+  get<T = any>(propertyPath: keyof K, defaultValue: NoInferType<T>): T;
   /**
    * Get a configuration value (either custom configuration or process environment variable)
    * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").
@@ -38,7 +38,7 @@ export class ConfigService {
    * @param propertyPath
    * @param defaultValue
    */
-  get<T = any>(propertyPath: string, defaultValue?: T): T | undefined {
+  get<T = any>(propertyPath: keyof K, defaultValue?: T): T | undefined {
     const validatedEnvValue = get(
       this.internalConfig[VALIDATED_ENV_PROPNAME],
       propertyPath,

--- a/lib/config.service.ts
+++ b/lib/config.service.ts
@@ -8,7 +8,7 @@ import {
 import { NoInferType } from './types';
 
 @Injectable()
-export class ConfigService<K = any> {
+export class ConfigService<K = Record<string, any>> {
   constructor(
     @Optional()
     @Inject(CONFIGURATION_TOKEN)

--- a/tests/e2e/optional-generic.spec.ts
+++ b/tests/e2e/optional-generic.spec.ts
@@ -1,0 +1,40 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from '../src/app.module';
+import { ConfigService } from '../../lib';
+
+describe('Optional Generic()', () => {
+  let app: INestApplication;
+  let module: TestingModule;
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      imports: [AppModule.withEnvVars()],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  it(`should allow a key of the interface`, () => {
+    const configService = module.get<ConfigService<{ PORT: string }>>(
+      ConfigService,
+    );
+
+    const port = configService.get('PORT');
+
+    expect(port).toBeTruthy();
+  });
+
+  it(`should allow any key without a generic`, () => {
+    const configService = module.get<ConfigService>(ConfigService);
+
+    const port = configService.get('PORT');
+
+    expect(port).toBeTruthy();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) [here](https://github.com/nestjs/docs.nestjs.com/pull/1257)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

`ConfigService` will accept any string for the property path

## What is the new behavior?

Can pass in an optional generic to `ConfigService` to validate the env variables being accessed.

If you have the following interface that matches the expected env variables

```
export interface EnvVariables {
   PORT: string;
   TIMEOUT: number;
}
```

Then when injecting `ConfigService` into a constructor the property pass will be validated again the keys of the generic type.

```
@Injectable()
class SomeService {
   constructor(private configService: ConfigService<EnvVariables>) {
      this.configService.get('PORT'); // This is ok
      this.configService.get('NOTHING'); // This will cause a type error
   }
}
```


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```