### PR TITLE
feat(core): add possibility to use a custom validate function for env validation

### DIFF
--- a/lib/config.module.ts
+++ b/lib/config.module.ts
@@ -46,7 +46,11 @@ export class ConfigModule {
         ...process.env,
       };
     }
-    if (options.validationSchema) {
+    if (options.validate) {
+      const validatedConfig = options.validate(config);
+      validatedEnvConfig = validatedConfig;
+      this.assignVariablesToProcess(validatedConfig);
+    } else if (options.validationSchema) {
       const validationOptions = this.getSchemaValidationOptions(options);
       const {
         error,

--- a/lib/interfaces/config-module-options.interface.ts
+++ b/lib/interfaces/config-module-options.interface.ts
@@ -28,6 +28,16 @@ export interface ConfigModuleOptions {
   encoding?: string;
 
   /**
+   * Function to validate env vars, it takes an object containing environment
+   * variables as input and outputs validated environment variables.
+   * If exception is thrown in the function it would prevent the application
+   * from bootstrapping.
+   * Also, environment variables can be edited through this function, changes
+   * will be reflected in process.env.
+   */
+  validate?: (config: Record<string, any>) => Record<string, any>;
+
+  /**
    * Environment variables validation schema (Joi).
    */
   validationSchema?: any;

--- a/lib/interfaces/config-module-options.interface.ts
+++ b/lib/interfaces/config-module-options.interface.ts
@@ -34,7 +34,7 @@ export interface ConfigModuleOptions {
 
   /**
    * Schema validation options.
-   * See: https://hapi.dev/family/joi/?v=16.1.8#anyvalidatevalue-options
+   * See: https://joi.dev/api/?v=17.3.0#anyvalidatevalue-options
    */
   validationOptions?: Record<string, any>;
 

--- a/tests/e2e/validate-function.spec.ts
+++ b/tests/e2e/validate-function.spec.ts
@@ -1,0 +1,88 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { join } from 'path';
+import { ConfigService } from '../../lib';
+import { AppModule } from '../src/app.module';
+
+describe('Schema validation', () => {
+  let app: INestApplication;
+  const errorMessage = 'Validation error';
+  const validate = (config: Record<string, any>) => {
+    if (!('PORT' in config && 'DATABASE_NAME' in config)) {
+      throw new Error(errorMessage);
+    }
+
+    return {};
+  };
+
+  it(`should prevent application from bootstrapping if error is thrown due to loaded env variables`, async () => {
+    let hasThrown = false;
+    try {
+      const module = await Test.createTestingModule({
+        imports: [AppModule.withValidateFunction(validate)],
+      }).compile();
+
+      app = module.createNestApplication();
+      await app.init();
+    } catch (err) {
+      hasThrown = true;
+      expect(err.message).toEqual(errorMessage);
+    }
+    expect(hasThrown).toBe(true);
+  });
+
+  it(`should prevent application from bootstrapping if error is thrown even when ignoreEnvFile is true`, async () => {
+    let hasThrown = false;
+    try {
+      const module = await Test.createTestingModule({
+        imports: [AppModule.withValidateFunction(validate, undefined, true)],
+      }).compile();
+
+      app = module.createNestApplication();
+      await app.init();
+    } catch (err) {
+      hasThrown = true;
+      expect(err.message).toEqual(errorMessage);
+    }
+    expect(hasThrown).toBe(true);
+  });
+
+  it(`should load env variables if everything is ok`, async () => {
+    let hasThrown = false;
+    const module = await Test.createTestingModule({
+      imports: [
+        AppModule.withValidateFunction(validate, join(__dirname, '.env.valid')),
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+
+    const configService = app.get(ConfigService);
+    expect(typeof configService.get('PORT')).not.toBe(undefined);
+    expect(typeof configService.get('DATABASE_NAME')).not.toBe(undefined);
+  });
+
+  it(`should parse loaded env variables`, async () => {
+    const validateAndTransform = (config: Record<string, any>) => {
+      return {
+        PORT: Number(config.PORT),
+        DATABASE_NAME: config.DATABASE_NAME,
+      };
+    };
+    const module = await Test.createTestingModule({
+      imports: [
+        AppModule.withValidateFunction(
+          validateAndTransform,
+          join(__dirname, '.env.valid'),
+        ),
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+
+    const configService = app.get(ConfigService);
+    expect(typeof configService.get('PORT')).toEqual('number');
+  });
+});

--- a/tests/src/app.module.ts
+++ b/tests/src/app.module.ts
@@ -91,6 +91,23 @@ export class AppModule {
     };
   }
 
+  static withValidateFunction(
+    validate: (config: Record<string, any>) => Record<string, any>,
+    envFilePath?: string,
+    ignoreEnvFile?: boolean,
+  ): DynamicModule {
+    return {
+      module: AppModule,
+      imports: [
+        ConfigModule.forRoot({
+          envFilePath,
+          ignoreEnvFile,
+          validate,
+        }),
+      ],
+    };
+  }
+
   static withForFeature(): DynamicModule {
     return {
       module: AppModule,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) -> see [here](https://github.com/nestjs/docs.nestjs.com/pull/1534) for the corresponding PR


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

Only `joi` validation is possible, which is forcing users to add this lib in addition to `class-validator`  


Issue Number: [318](https://github.com/nestjs/config/issues/318)


## What is the new behavior?

A user can now choose between `class-validator` and `joi` to validate env variables

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
