### PR TITLE
fix(): should get from internal value before check process.env

### DIFF
--- a/lib/config.service.ts
+++ b/lib/config.service.ts
@@ -57,14 +57,14 @@ export class ConfigService<K = Record<string, any>> {
       return validatedEnvValue;
     }
 
-    const processEnvValue = this.getFromProcessEnv(propertyPath, defaultValue);
-    if (!isUndefined(processEnvValue)) {
-      return processEnvValue;
-    }
-
     const internalValue = this.getFromInternalConfig(propertyPath);
     if (!isUndefined(internalValue)) {
       return internalValue;
+    }
+
+    const processEnvValue = this.getFromProcessEnv(propertyPath, defaultValue);
+    if (!isUndefined(processEnvValue)) {
+      return processEnvValue;
     }
 
     return defaultValue;

--- a/tests/e2e/load-env-with-same-key.spec.ts
+++ b/tests/e2e/load-env-with-same-key.spec.ts
@@ -1,0 +1,25 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { AppModule } from '../src/app.module';
+
+describe('Environment variables', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppModule.withLoadedSameKeyConfigurations()],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  it(`should return loaded env variables`, () => {
+    const port = app.get(AppModule).getPortInSameKeyConfig();
+    expect(port).toEqual(3000);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});

--- a/tests/src/app.module.ts
+++ b/tests/src/app.module.ts
@@ -6,6 +6,7 @@ import { ConfigModule } from '../../lib/config.module';
 import { ConfigService } from '../../lib/config.service';
 import databaseConfig from './database.config';
 import nestedDatabaseConfig from './nested-database.config';
+import sameKeyDatabaseConfig from './same-key-database.config';
 
 @Module({})
 export class AppModule {
@@ -69,6 +70,18 @@ export class AppModule {
       imports: [
         ConfigModule.forRoot({
           load: [databaseConfig],
+        }),
+      ],
+    };
+  }
+
+  static withLoadedSameKeyConfigurations(): DynamicModule {
+    return {
+      module: AppModule,
+      imports: [
+        ConfigModule.forRoot({
+          envFilePath: join(__dirname, '.env'),
+          load: [sameKeyDatabaseConfig],
         }),
       ],
     };
@@ -145,5 +158,9 @@ export class AppModule {
 
   getNestedDatabaseHost() {
     return this.configService.get('database.driver.host');
+  }
+
+  getPortInSameKeyConfig() {
+    return this.configService.get('PORT');
   }
 }

--- a/tests/src/same-key-database.config.ts
+++ b/tests/src/same-key-database.config.ts
@@ -1,0 +1,3 @@
+export default () => ({
+  PORT: 3000,
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?


In the load function, if the name is same with process.env. It will take value of proeces.env instead of internalConfig.

In the source code:

```ts
    const processEnvValue = this.getFromProcessEnv(propertyPath, defaultValue);
    if (!isUndefined(processEnvValue)) {
      return processEnvValue;
    }

    const internalValue = this.getFromInternalConfig(propertyPath);
    if (!isUndefined(internalValue)) {
      return internalValue;
    }
``` 

In .env:
```
DB_POOL_MAX_CONNECTION=10
DB_SYNC=true
```

In load function:

```ts
export const Config = () => {
  const config = {
    'DB_POOL_MAX_CONNECTION': parseInt(
      process.env['DB_POOL_MAX_CONNECTION'],
    ),
    'DB_SYNC': process.env['DB_SYNC'] === 'true'
  };
  return config;
};
```

In app.module:

```ts
@Module({
  imports: [
    ConfigModule.forRoot({ isGlobal: true, load: [Config] }),
 ],
})
```

The result when you call `ConfigService.get` will get the value from process.env. It means the load function is useless, if you keep this order.

Issue Number: N/A

## What is the new behavior?

It will check internal value before process.env


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information