### PR TITLE
feat(): Infer return type of ConfigService.get method

### DIFF
--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,2 +1,1 @@
 export * from './config.type';
-export * from './no-infer.type';

--- a/lib/types/no-infer.type.ts
+++ b/lib/types/no-infer.type.ts
@@ -1,1 +1,0 @@
-export type NoInferType<T> = [T][T extends any ? 0 : never];

--- a/tests/e2e/cache.spec.ts
+++ b/tests/e2e/cache.spec.ts
@@ -21,13 +21,13 @@ describe('Cache', () => {
     });
 
     it(`should return loaded env variables from vars`, () => {
-      const configService = app.get(ConfigService);
+      const configService: ConfigService<{ NAME: string }> = app.get(ConfigService);
       expect(configService.get('NAME')).toEqual('TEST');
     });
 
     it(`should return new vars`, () => {
       process.env['NAME'] = 'CHANGED';
-      const configService = app.get(ConfigService);
+      const configService: ConfigService<{ NAME: string }> = app.get(ConfigService);
       expect(configService.get('NAME')).toEqual('CHANGED');
     });
   });
@@ -44,13 +44,13 @@ describe('Cache', () => {
     });
 
     it(`should return loaded env variables from vars`, () => {
-      const configService = app.get(ConfigService);
+      const configService: ConfigService<{ NAME: string }> = app.get(ConfigService);
       expect(configService.get('NAME')).toEqual('TEST');
     });
 
     it(`should return cached vars`, () => {
       process.env['NAME'] = 'CHANGED';
-      const configService = app.get(ConfigService);
+      const configService: ConfigService<{ NAME: string }> = app.get(ConfigService);
       expect(configService.get('NAME')).toEqual('TEST');
     });
   });

--- a/tests/e2e/load-priority.spec.ts
+++ b/tests/e2e/load-priority.spec.ts
@@ -22,7 +22,7 @@ describe('Environment variables and .env files', () => {
     });
 
     it(`should return loaded env variables from vars and dotenv`, () => {
-      const configService = app.get(ConfigService);
+      const configService: ConfigService<{ [key in 'PORT' | 'NAME']: unknown }> = app.get(ConfigService);
       expect(configService.get('PORT')).toEqual('4000');
       expect(configService.get('NAME')).toEqual('TEST');
     });
@@ -40,7 +40,7 @@ describe('Environment variables and .env files', () => {
     });
 
     it('should choose env vars over dotenv', () => {
-      const configService = app.get(ConfigService);
+      const configService: ConfigService<{ PORT: unknown }> = app.get(ConfigService);
       expect(configService.get('PORT')).toEqual('8000');
     });
   });
@@ -59,7 +59,7 @@ describe('Environment variables and .env files', () => {
     });
 
     it('should choose env vars over dotenv', () => {
-      const configService = app.get(ConfigService);
+      const configService: ConfigService<{ PORT: unknown }> = app.get(ConfigService);
       expect(configService.get('PORT')).toEqual(8000);
     });
   });

--- a/tests/e2e/optional-generic.spec.ts
+++ b/tests/e2e/optional-generic.spec.ts
@@ -21,13 +21,13 @@ describe('Optional Generic()', () => {
       ConfigService,
     );
 
-    const port = configService.get('PORT');
+    const port: string = configService.get('PORT');
     expect(port).toBeTruthy();
   });
 
   it(`should allow any key without a generic`, () => {
-    const configService = moduleRef.get<ConfigService>(ConfigService);
-    const port = configService.get('PORT');
+    const configService = moduleRef.get<ConfigService<{ PORT: string }>>(ConfigService);
+    const port: string = configService.get('PORT');
 
     expect(port).toBeTruthy();
   });

--- a/tests/e2e/validate-function.spec.ts
+++ b/tests/e2e/validate-function.spec.ts
@@ -47,7 +47,6 @@ describe('Schema validation', () => {
   });
 
   it(`should load env variables if everything is ok`, async () => {
-    let hasThrown = false;
     const module = await Test.createTestingModule({
       imports: [
         AppModule.withValidateFunction(validate, join(__dirname, '.env.valid')),
@@ -57,7 +56,7 @@ describe('Schema validation', () => {
     app = module.createNestApplication();
     await app.init();
 
-    const configService = app.get(ConfigService);
+    const configService: ConfigService<{ [key in 'PORT' | 'DATABASE_NAME']: unknown }> = app.get(ConfigService);
     expect(typeof configService.get('PORT')).not.toBe(undefined);
     expect(typeof configService.get('DATABASE_NAME')).not.toBe(undefined);
   });
@@ -81,7 +80,7 @@ describe('Schema validation', () => {
     app = module.createNestApplication();
     await app.init();
 
-    const configService = app.get(ConfigService);
+    const configService: ConfigService<{ PORT: unknown }> = app.get(ConfigService);
     expect(typeof configService.get('PORT')).toEqual('number');
   });
 });

--- a/tests/e2e/validation-schema.spec.ts
+++ b/tests/e2e/validation-schema.spec.ts
@@ -45,7 +45,7 @@ describe('Schema validation', () => {
     app = module.createNestApplication();
     await app.init();
 
-    const configService = app.get(ConfigService);
+    const configService: ConfigService<{ PORT: unknown }> = app.get(ConfigService);
     expect(typeof configService.get('PORT')).toEqual('number');
   });
 });

--- a/tests/src/app.module.ts
+++ b/tests/src/app.module.ts
@@ -10,7 +10,7 @@ import nestedDatabaseConfig from './nested-database.config';
 @Module({})
 export class AppModule {
   constructor(
-    private readonly configService: ConfigService,
+    private readonly configService: ConfigService<{ 'database.host': string, 'database.driver.host': string }>,
     @Optional()
     @Inject(databaseConfig.KEY)
     private readonly dbConfig: ConfigType<typeof databaseConfig>,
@@ -135,7 +135,7 @@ export class AppModule {
     return process.env;
   }
 
-  getDatabaseHost() {
+  getDatabaseHost(): string {
     return this.configService.get('database.host');
   }
 
@@ -143,7 +143,7 @@ export class AppModule {
     return this.dbConfig;
   }
 
-  getNestedDatabaseHost() {
+  getNestedDatabaseHost(): string {
     return this.configService.get('database.driver.host');
   }
 }


### PR DESCRIPTION
The ConfigService class has a generic template which allows to infer the
return type when getting a property.

BREAKING CHANGE:

The generic type of the get method is not the return type anymore.
This generic type is now the key in config. Most of the time this
generic parameter can be omit.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

```typescript
type Configuration = { PORT: number };
let configSerice: ConfigService<Configuration>;
configService.get('PORT'); // was `any`
configService.get<Configuration['PORT']>('PORT'); // was `number` but redundant
(configService as ConfigService).get('PORT'); // was `any`
```


## What is the new behavior?

```typescript
type Configuration = { PORT: number };
let configSerice: ConfigService<Configuration>;
configService.get('PORT'); // is `number`
(configService as ConfigService).get('PORT'); // is `unknown`
```

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

The generic argument of `get` cannot be used to defined return type anymore. If the `ConfigService` is typed, every call to `get` does not need generics anymore.

```typescript
let configSerice: ConfigService<{PORT:number}>;
// Previous call
const port = configService.get<number>('PORT');
// Now
const port = confgiService.get('PORT');
```

However if the `ConfigService` is not typed, the method `get` will return `unkown`. In this case we still can cast the return type.

```typescript
let configSerice: ConfigService;
// Previous call
const port = configService.get<number>('PORT');
// Now
const port = confgiService.get('PORT') as number;
```