### PR TITLE
fix(types): stop before try to evaluate `any` as a path

### DIFF
--- a/lib/types/path-value.type.ts
+++ b/lib/types/path-value.type.ts
@@ -22,8 +22,10 @@ export type PathImpl<T, Key extends keyof T> = Key extends string
 export type PathImpl2<T> = PathImpl<T, keyof T> | keyof T;
 
 export type Path<T> = keyof T extends string
-  ? PathImpl2<T> extends string | keyof T
-    ? PathImpl2<T>
+  ? PathImpl2<T> extends infer P
+    ? P extends string | keyof T
+      ? P
+      : keyof T
     : keyof T
   : never;
 

--- a/lib/types/path-value.type.ts
+++ b/lib/types/path-value.type.ts
@@ -1,5 +1,17 @@
+/**
+ * Evaluates to `true` if `T` is `any`. `false` otherwise.
+ * (c) https://stackoverflow.com/a/68633327/5290447
+ */
+type IsAny<T> = unknown extends T
+  ? [keyof T] extends [never]
+    ? false
+    : true
+  : false;
+
 export type PathImpl<T, Key extends keyof T> = Key extends string
-  ? T[Key] extends Record<string, any>
+  ? IsAny<T[Key]> extends true
+    ? never
+    : T[Key] extends Record<string, any>
     ?
         | `${Key}.${PathImpl<T[Key], Exclude<keyof T[Key], keyof any[]>> &
             string}`


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: fixes #906

![image](https://user-images.githubusercontent.com/13461315/160268677-0bf79ab9-e773-4f40-a719-cbf76d123582.png)

## What is the new behavior?

we can have keys with the type `any` when using `ConfigService#get` typed. See:

![image](https://user-images.githubusercontent.com/13461315/160268659-1703ece2-e1a8-4d14-ac71-3a661a92acef.png)

![image](https://user-images.githubusercontent.com/13461315/160268690-54c07b5f-79a3-4892-80a6-400c6883e0b6.png)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

The second commit is just a minor performance improvement **not related** with the original Issue. It was made to avoid computing `PathImpl2<T>` twice by using the [`infer`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#type-inference-in-conditional-types) keyword to cache the first result.  
I can drop that commit if you prefer the old version in favor of readability.
