### PR TITLE
refactor(utils): generate unique id only when needed

### DIFF
--- a/lib/utils/create-config-factory.util.ts
+++ b/lib/utils/create-config-factory.util.ts
@@ -7,9 +7,8 @@ import { ConfigFactoryKeyHost } from './register-as.util';
 export function createConfigProvider(
   factory: ConfigFactory & ConfigFactoryKeyHost,
 ): FactoryProvider {
-  const uniqId = uuid();
   return {
-    provide: factory.KEY || getConfigToken(uniqId),
+    provide: factory.KEY || getConfigToken(uuid()),
     useFactory: factory,
     inject: [],
   };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

`uuidv4()` is being called even if it's not used.

## What is the new behavior?

Inlines the `uuid()` call to rely on JS short circuit on OR operation to generate the uuid v4 only if the factory key was not provided. The `factory.KEY` will always be defined for those that are using `registerAs`, thus they can avoid the computation of `uuidv4()`

```
$ node
> const foo = () => {}
> const bar = () => console.log('called')
> false || foo( bar() )
called
undefined
> true || foo( bar() )
true
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No