### PR TITLE
feat: add ConfigService#getOrThrow()

### DIFF
--- a/lib/config.service.ts
+++ b/lib/config.service.ts
@@ -146,7 +146,10 @@ export class ConfigService<
    * @param propertyPath
    * @param defaultValue
    */
-  getOrThrow<T = any>(propertyPath: KeyOf<K>, defaultValue: NoInferType<T>): T;
+  getOrThrow<T = any>(
+    propertyPath: KeyOf<K>,
+    defaultValue: NoInferType<T>,
+  ): Exclude<T, undefined>;
   /**
    * Get a configuration value (either custom configuration or process environment variable)
    * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").
@@ -160,7 +163,7 @@ export class ConfigService<
     propertyPath: P,
     defaultValue: NoInferType<R>,
     options: ConfigGetOptions,
-  ): R;
+  ): Exclude<R, undefined>;
   /**
    * Get a configuration value (either custom configuration or process environment variable)
    * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").
@@ -173,17 +176,17 @@ export class ConfigService<
     propertyPath: KeyOf<K>,
     defaultValueOrOptions?: T | ConfigGetOptions,
     options?: ConfigGetOptions,
-  ): T {
+  ): Exclude<T, undefined> {
     // @ts-expect-error Bypass method overloads
-    const value = this.get(propertyPath, defaultValueOrOptions, options) as T | undefined;
+    const value = this.get(propertyPath, defaultValueOrOptions, options) as
+      | T
+      | undefined;
 
     if (isUndefined(value)) {
-      throw new TypeError(
-        `Configuration key "${propertyPath}" does not exist`,
-      );
+      throw new TypeError(`Configuration key "${propertyPath}" does not exist`);
     }
 
-    return value;
+    return value as Exclude<T, undefined>;
   }
 
   private getFromCache<T = any>(

--- a/lib/config.service.ts
+++ b/lib/config.service.ts
@@ -134,7 +134,7 @@ export class ConfigService<
    * @param propertyPath
    * @param options
    */
-  getOrThrow<T = K, P extends Path<T> = any, R = PathValue<T, P>>(
+  getOrThrow<T = K, P extends Path<T> = any>(
     propertyPath: P,
     options: ConfigGetOptions,
   ): Exclude<T, undefined>;
@@ -183,7 +183,7 @@ export class ConfigService<
       | undefined;
 
     if (isUndefined(value)) {
-      throw new TypeError(`Configuration key "${propertyPath}" does not exist`);
+      throw new TypeError(`Configuration key "${propertyPath.toString()}" does not exist`);
     }
 
     return value as Exclude<T, undefined>;

--- a/lib/config.service.ts
+++ b/lib/config.service.ts
@@ -122,6 +122,70 @@ export class ConfigService<
     return defaultValue as T;
   }
 
+  /**
+   * Get a configuration value (either custom configuration or process environment variable)
+   * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").
+   * @param propertyPath
+   */
+  getOrThrow<T = any>(propertyPath: KeyOf<K>): Exclude<T, undefined>;
+  /**
+   * Get a configuration value (either custom configuration or process environment variable)
+   * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").
+   * @param propertyPath
+   * @param options
+   */
+  getOrThrow<T = K, P extends Path<T> = any, R = PathValue<T, P>>(
+    propertyPath: P,
+    options: ConfigGetOptions,
+  ): Exclude<T, undefined>;
+  /**
+   * Get a configuration value (either custom configuration or process environment variable)
+   * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").
+   * It returns a default value if the key does not exist.
+   * If no default value was provided an exception will be thrown.
+   * @param propertyPath
+   * @param defaultValue
+   */
+  getOrThrow<T = any>(propertyPath: KeyOf<K>, defaultValue: NoInferType<T>): T;
+  /**
+   * Get a configuration value (either custom configuration or process environment variable)
+   * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").
+   * It returns a default value if the key does not exist.
+   * If no default value was provided an exception will be thrown.
+   * @param propertyPath
+   * @param defaultValue
+   * @param options
+   */
+  getOrThrow<T = K, P extends Path<T> = any, R = PathValue<T, P>>(
+    propertyPath: P,
+    defaultValue: NoInferType<R>,
+    options: ConfigGetOptions,
+  ): R;
+  /**
+   * Get a configuration value (either custom configuration or process environment variable)
+   * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").
+   * It returns a default value if the key does not exist.
+   * If no default value was provided an exception will be thrown.
+   * @param propertyPath
+   * @param defaultValueOrOptions
+   */
+  getOrThrow<T = any>(
+    propertyPath: KeyOf<K>,
+    defaultValueOrOptions?: T | ConfigGetOptions,
+    options?: ConfigGetOptions,
+  ): T {
+    // @ts-expect-error Bypass method overloads
+    const value = this.get(propertyPath, defaultValueOrOptions, options) as T | undefined;
+
+    if (isUndefined(value)) {
+      throw new TypeError(
+        `Configuration key "${propertyPath}" does not exist`,
+      );
+    }
+
+    return value;
+  }
+
   private getFromCache<T = any>(
     propertyPath: KeyOf<K>,
     defaultValue?: T,

--- a/lib/config.service.ts
+++ b/lib/config.service.ts
@@ -142,7 +142,7 @@ export class ConfigService<
    * Get a configuration value (either custom configuration or process environment variable)
    * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").
    * It returns a default value if the key does not exist.
-   * If no default value was provided an exception will be thrown.
+   * If the default value is undefined an exception will be thrown.
    * @param propertyPath
    * @param defaultValue
    */
@@ -154,7 +154,7 @@ export class ConfigService<
    * Get a configuration value (either custom configuration or process environment variable)
    * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").
    * It returns a default value if the key does not exist.
-   * If no default value was provided an exception will be thrown.
+   * If the default value is undefined an exception will be thrown.
    * @param propertyPath
    * @param defaultValue
    * @param options
@@ -168,7 +168,7 @@ export class ConfigService<
    * Get a configuration value (either custom configuration or process environment variable)
    * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").
    * It returns a default value if the key does not exist.
-   * If no default value was provided an exception will be thrown.
+   * If the default value is undefined an exception will be thrown.
    * @param propertyPath
    * @param defaultValueOrOptions
    */


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Users must either use full schema validation of configuration values or write their own `.getOrThrow()` method.

Issue Number: N/A

## What is the new behavior?

`ConfigService#getOrThrow()` can be used to get a configuration value by key, and throw if it does not exist (and no default value was provided).

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

[Relevant Discord conversation](https://discord.com/channels/520622812742811698/939229065527820369/971538667195744317).