### PR TITLE
feat(expand variables): expand process.env vars from dotenv file

### DIFF
--- a/lib/config.module.ts
+++ b/lib/config.module.ts
@@ -54,11 +54,10 @@ export class ConfigModule {
     let validatedEnvConfig: Record<string, any> | undefined = undefined;
     let config = options.ignoreEnvFile ? {} : this.loadEnvFile(options);
 
-    if (!options.ignoreEnvVars) {
-      config = {
-        ...config,
-        ...process.env,
-      };
+    if (options.expandVariables || !options.ignoreEnvVars) {
+      const expandOptions: DotenvExpandOptions = typeof options.expandVariables === 'object' ? options.expandVariables : {};
+      config = expand({ ...expandOptions, parsed: {...config,...(!expandOptions.ignoreProcessEnv && !options.ignoreEnvVars && process.env )} }).parsed || config;
+ 
     }
     if (options.validate) {
       const validatedConfig = options.validate(config);
@@ -183,10 +182,7 @@ export class ConfigModule {
           dotenv.parse(fs.readFileSync(envFilePath)),
           config,
         );
-        if (options.expandVariables) {
-          const expandOptions: DotenvExpandOptions = typeof options.expandVariables === 'object' ? options.expandVariables : {};
-          config = expand({ ...expandOptions, parsed: config }).parsed || config;
-        }
+  
       }
     }
     return config;

--- a/tests/e2e/load-env-expanded-process-variables.spec.ts
+++ b/tests/e2e/load-env-expanded-process-variables.spec.ts
@@ -1,0 +1,27 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { AppModule } from '../src/app.module';
+
+describe('Environment variables', () => {
+  let app: INestApplication;
+
+  process.env.DB_URL = 'protocol://${db_username}:${db_password}@127.0.0.1/test';
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppModule.withExpandedEnvVars()],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  it(`should return loaded env variables`, () => {
+    const envVars = app.get(AppModule).getEnvVariables();
+    expect(envVars.DB_URL).toEqual('protocol://sa:AStrongPassword@127.0.0.1/test');
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});

--- a/tests/src/.env.expanded
+++ b/tests/src/.env.expanded
@@ -1,2 +1,4 @@
 URL=myapp.test
 EMAIL=support@${URL}
+db_username=sa
+db_password=AStrongPassword


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Expand variable feature is only limited to `.env` files, so dotenv-expand syntax would not work for env vars loaded from `process.env`.

Issue Number: N/A


## What is the new behavior?
This PR will expand env vars on environmental variables.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This feature is helpful, if process.env is loaded from docker-compose and wants dynamically populate the DB_PASSWORD from dotenv file. 

Usecase:-

```
.env
DB_PASSWORD=paSSwOrd 
```
`process.env.DB_URL = protocol://user@${DB_PASSWORD}:host.com/db`

_Earlier :_ 
when loaded from config, earlier behavior will be 
`protocol://user@${DB_PASSWORD}:host/db`

_Behavior of this changes_
when loaded from config, current behavior will be 
`protocol://user@paSSwOrd:host/db`


