### PR TITLE
feat: add ignore env on get option

### DIFF
--- a/lib/config.module.ts
+++ b/lib/config.module.ts
@@ -92,6 +92,7 @@ export class ConfigModule {
         if (options.cache) {
           (configService as any).isCacheEnabled = true;
         }
+        (configService as any).ignoreEnvVarsOnGet = !!options.ignoreEnvVarsOnGet;
         return configService;
       },
       inject: [CONFIGURATION_SERVICE_TOKEN, ...configProviderTokens],

--- a/lib/config.service.ts
+++ b/lib/config.service.ts
@@ -16,7 +16,7 @@ import { NoInferType, Path, PathValue } from './types';
 type ExcludeUndefinedIf<
   ExcludeUndefined extends boolean,
   T,
-> = ExcludeUndefined extends true ? Exclude<T, undefined> : T | undefined;
+  > = ExcludeUndefined extends true ? Exclude<T, undefined> : T | undefined;
 
 export interface ConfigGetOptions {
   /**
@@ -33,7 +33,7 @@ type KeyOf<T> = keyof T extends never ? string : keyof T;
 export class ConfigService<
   K = Record<string, unknown>,
   WasValidated extends boolean = false,
-> {
+  > {
   private set isCacheEnabled(value: boolean) {
     this._isCacheEnabled = value;
   }
@@ -42,8 +42,17 @@ export class ConfigService<
     return this._isCacheEnabled;
   }
 
+  private set ignoreEnvVarsOnGet(value: boolean) {
+    this._ignoreEnvVarsOnGet = value;
+  }
+
+  private get ignoreEnvVarsOnGet(): boolean {
+    return this._ignoreEnvVarsOnGet;
+  }
+
   private readonly cache: Partial<K> = {} as any;
   private _isCacheEnabled = false;
+  private _ignoreEnvVarsOnGet = false;
 
   constructor(
     @Optional()
@@ -109,9 +118,11 @@ export class ConfigService<
         ? undefined
         : defaultValueOrOptions;
 
-    const processEnvValue = this.getFromProcessEnv(propertyPath, defaultValue);
-    if (!isUndefined(processEnvValue)) {
-      return processEnvValue;
+    if (!this.ignoreEnvVarsOnGet) {
+      const processEnvValue = this.getFromProcessEnv(propertyPath, defaultValue);
+      if (!isUndefined(processEnvValue)) {
+        return processEnvValue;
+      }
     }
 
     const internalValue = this.getFromInternalConfig(propertyPath);

--- a/lib/config.service.ts
+++ b/lib/config.service.ts
@@ -98,7 +98,7 @@ export class ConfigService<
     options: ConfigGetOptions,
   ): R;
   /**
-   * Get a configuration value (either custom configuration or process environment variable)
+   * Get a configuration value (either custom configuration or process environment variable if not disabled using "ignoreEnvVarsOnGet")
    * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").
    * It returns a default value if the key does not exist.
    * @param propertyPath

--- a/lib/interfaces/config-module-options.interface.ts
+++ b/lib/interfaces/config-module-options.interface.ts
@@ -24,6 +24,11 @@ export interface ConfigModuleOptions {
    * If "true", predefined environment variables will not be validated.
    */
   ignoreEnvVars?: boolean;
+  
+  /**
+   * If "true", environment variables will not be considered on get.
+   */
+   ignoreEnvVarsOnGet?: boolean;
 
   /**
    * Path to the environment file(s) to be loaded.

--- a/tests/e2e/ignore-process-env-on-get.spec.ts
+++ b/tests/e2e/ignore-process-env-on-get.spec.ts
@@ -1,0 +1,37 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '../../lib';
+import { AppModule } from '../src/app.module';
+
+describe('Ignore Env Varibles on get', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    process.env.URL = 'process-app.test';
+    process.env.VAR_NAME = 'VAR_VALUE';
+
+    const module = await Test.createTestingModule({
+      imports: [AppModule.withIgnoreEnvVarsOnGet()],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  it(`should not return env variable value`, () => {
+    const configService = app.get(ConfigService);
+    expect(configService.get<string>('VAR_NAME')).toEqual(undefined);
+  });
+
+  
+  it(`should return variable from load instead of env`, () => {
+    const configService = app.get(ConfigService);
+    expect(configService.get<string>('URL')).toEqual('override-from-load');
+  });
+
+  afterEach(async () => {
+    process.env.URL = undefined
+    process.env.VAR_NAME = undefined;
+    await app.close();
+  });
+});

--- a/tests/src/app.module.ts
+++ b/tests/src/app.module.ts
@@ -183,6 +183,20 @@ export class AppModule {
     };
   }
 
+  static withIgnoreEnvVarsOnGet(): DynamicModule {
+    return {
+      module: AppModule,
+      imports: [
+        ConfigModule.forRoot({
+          ignoreEnvVarsOnGet: true,
+          load: [() => ({
+            URL: 'override-from-load'
+          })],
+        }),
+      ],
+    };
+  }
+
   getEnvVariables() {
     return process.env;
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Up to now, there is no way to avoid the config service to read from the env. This can cause some problems while testing some features and trying to inject a specific configuration value (that could be overridden by process.env on get)

Issue Number: #245


## What is the new behavior?
This pr adds `ignoreEnvVarsOnGet` that will not consider process.env while getting the variables from the ConfigService. So you can be sure that the returned value will be the one in the factory

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
