### PR TITLE
fix(common): infer getOrThrow return value

### DIFF
--- a/lib/config.service.ts
+++ b/lib/config.service.ts
@@ -134,10 +134,10 @@ export class ConfigService<
    * @param propertyPath
    * @param options
    */
-  getOrThrow<T = K, P extends Path<T> = any>(
+  getOrThrow<T = K, P extends Path<T> = any, R = PathValue<T, P>>(
     propertyPath: P,
     options: ConfigGetOptions,
-  ): Exclude<T, undefined>;
+  ): Exclude<R, undefined>;
   /**
    * Get a configuration value (either custom configuration or process environment variable)
    * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").

--- a/tests/e2e/optional-generic.spec.ts
+++ b/tests/e2e/optional-generic.spec.ts
@@ -39,6 +39,22 @@ describe('Optional Generic()', () => {
     expect(testWithDefaultValue).toBeTruthy();
   });
 
+  it(`should infer type from a dot notation (getOrThrow)`, () => {
+    const configService =
+      moduleRef.get<ConfigService<{ obj: { test: boolean; test2?: boolean } }>>(
+        ConfigService,
+      );
+
+    const obj = configService.getOrThrow('obj', { infer: true });
+    const test = configService.getOrThrow('obj.test', { infer: true });
+    const testWithDefaultValue = configService.getOrThrow('obj.test2', true, {
+      infer: true,
+    });
+    expect(obj?.test).toEqual('true');
+    expect(test).toEqual('true');
+    expect(testWithDefaultValue).toBeTruthy();
+  });
+
   it(`should allow any key without a generic`, () => {
     const configService = moduleRef.get<ConfigService>(ConfigService);
     const port = configService.get('PORT');


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently `getOrThrow` return type is whole config object instead of `propertyPath` type.

Issue Number: N/A


## What is the new behavior?
`getOrThrow` return type is same as `K[propertyPath]`

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
