### PR TITLE
fix(): do not remove undefined from ConfigService.get return type

### DIFF
--- a/lib/config.service.ts
+++ b/lib/config.service.ts
@@ -8,15 +8,15 @@ import {
 import { NoInferType, Path, PathValue } from './types';
 
 /**
- * `ExcludeUndefinedIf<ExcludeUndefined, T>
+ * `ValidatedResult<WasValidated, T>
  *
- * If `ExcludeUndefined` is `true`, remove `undefined` from `T`.
+ * If `WasValidated` is `true`, return `T`.
  * Otherwise, constructs the type `T` with `undefined`.
  */
-type ExcludeUndefinedIf<
-  ExcludeUndefined extends boolean,
+type ValidatedResult<
+  WasValidated extends boolean,
   T,
-> = ExcludeUndefined extends true ? Exclude<T, undefined> : T | undefined;
+> = WasValidated extends true ? T : T | undefined;
 
 export interface ConfigGetOptions {
   /**
@@ -56,7 +56,7 @@ export class ConfigService<
    * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").
    * @param propertyPath
    */
-  get<T = any>(propertyPath: KeyOf<K>): ExcludeUndefinedIf<WasValidated, T>;
+  get<T = any>(propertyPath: KeyOf<K>): ValidatedResult<WasValidated, T>;
   /**
    * Get a configuration value (either custom configuration or process environment variable)
    * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").
@@ -66,7 +66,7 @@ export class ConfigService<
   get<T = K, P extends Path<T> = any, R = PathValue<T, P>>(
     propertyPath: P,
     options: ConfigGetOptions,
-  ): ExcludeUndefinedIf<WasValidated, R>;
+  ): ValidatedResult<WasValidated, R>;
   /**
    * Get a configuration value (either custom configuration or process environment variable)
    * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The return type of a validated `ConfigService.get` excludes `undefined`. This hides null errors in the following case.

```typescript
class Env {
    OPT?: string
}
const configService = app.get<ConfigService<Env, true>>(ConfigService);

const opt = configService.get('OPT', {infer: true}) // type is: string, should be string | undefined
const hasCat = opt.includes('🐱') // Will result in runtime error because opt is undefined
``` 

Issue Number: #1302


## What is the new behavior?
The return type now no longer excludes undefined if `WasValidated` is true.


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Users that have _strictNullChecks_ enabled, have optional properties on their Env class, and depend on the behavior of `ConfigService.get` stripping `undefined` from the return type will receive type errors. Example of code that would now result in errors:


```typescript
class Env {
    mandatoryString?: string
}

const configService = app.get<ConfigService<Env, true>>(ConfigService);
const hasCat = configService.get('mandatoryString', {infer: true}).includes('🐱')
```
The TypeScript error raised:

```
src/file.ts:??:20 - error TS2532: Object is possibly 'undefined'.

??     const hasCat = configService.get('mandatoryString', {infer: true}).includes('🐱')
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
``` 

I would argue that their types are wrong and this is exposed by this PR.