### PR TITLE
fix(): prevent unexpected process env stringification

### DIFF
--- a/lib/config.module.ts
+++ b/lib/config.module.ts
@@ -192,13 +192,18 @@ export class ConfigModule {
     return config;
   }
 
-  private static assignVariablesToProcess(config: Record<string, any>) {
+  private static assignVariablesToProcess(config: Record<string, unknown>) {
     if (!isObject(config)) {
       return;
     }
     const keys = Object.keys(config).filter(key => !(key in process.env));
     keys.forEach(
-      key => (process.env[key] = (config as Record<string, any>)[key]),
+      key => {
+        const value = config[key];
+        if (typeof value === 'string') {
+          process.env[key] = value;
+        }
+      },
     );
   }
 

--- a/tests/e2e/optional.spec.ts
+++ b/tests/e2e/optional.spec.ts
@@ -1,0 +1,33 @@
+import { Test } from '@nestjs/testing';
+import { AppModule } from '../src/app.module';
+import { ConfigService } from '../../lib';
+
+describe('Optional environment variables', () => {
+  it('should return undefined for optional variables', async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppModule.withValidateFunction(() => ({
+        optional: undefined,
+      }))],
+    }).compile();
+
+    const app = module.createNestApplication();
+    await app.init();
+
+    const optional = module.get(ConfigService).get('optional')
+
+    expect(optional).toEqual(undefined)
+  });
+
+  it('should not assign complex objects back to process.env', async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppModule.withValidateFunction(() => ({
+        complex: {hello: 'there'},
+      }))],
+    }).compile();
+
+    const app = module.createNestApplication();
+    await app.init();
+
+    expect(process.env.complex).toEqual(undefined)
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
- Environment variables are assigned back to `process.env` resulting in unexpected stringification. This stringification is deprecated and might result in a runtime error in the future. See <https://nodejs.org/api/process.html#processenv>.
- The return value for an undefined variable from `ConfigService.get` is the string `'undefined'`.

Issue Number: Closes #1302, address part 1.


## What is the new behavior?
- Only strings are assigned back to `process.env`
- Undefined variables result in `undefined` as return type from `ConfigService.get`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No, unless someone was depending on `[Object object]` in `process.env`