### PR TITLE
pref():import lodash efficiently

### DIFF
--- a/lib/config.service.ts
+++ b/lib/config.service.ts
@@ -1,6 +1,8 @@
 import { Inject, Injectable, Optional } from '@nestjs/common';
 import { isUndefined } from '@nestjs/common/utils/shared.utils';
-import { get, has, set } from 'lodash';
+import get from 'lodash/get';
+import has from 'lodash/has';
+import set from 'lodash/set';
 import {
   CONFIGURATION_TOKEN,
   VALIDATED_ENV_PROPNAME,

--- a/lib/utils/merge-configs.util.ts
+++ b/lib/utils/merge-configs.util.ts
@@ -1,4 +1,4 @@
-import { set } from 'lodash';
+import set from 'lodash/set';
 
 export function mergeConfigObject(
   host: Record<string, any>,


### PR DESCRIPTION
this is the recommended way to load only the methods needed instead of entire lodash.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
lodash is imported entirely in to the package. when most of it not needed at all.
it makes 78.3% of the bundle!

Issue Number: N/A


## What is the new behavior?
imports only the relevant methods. This is the recommended way to pick methods from lodash.
This improves pull request 792, which moved to using the full lodash package,
but made inefficient imports.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
pull request improved: https://github.com/nestjs/config/pull/792/
article about importing lodash: https://www.labnol.org/code/import-lodash-211117
