### PR TITLE
Fix(expand): fix dotenv-expand options support

### DIFF
--- a/lib/config.module.ts
+++ b/lib/config.module.ts
@@ -188,8 +188,15 @@ export class ConfigModule {
             typeof options.expandVariables === 'object'
               ? options.expandVariables
               : {};
+          const parsedInExpandOptions = expandOptions?.parsed;
+
           config =
-            expand({ ...expandOptions, parsed: config }).parsed || config;
+            expand({
+              ...expandOptions,
+              parsed: parsedInExpandOptions
+                ? { ...parsedInExpandOptions, ...config }
+                : config,
+            }).parsed || config;
         }
       }
     }


### PR DESCRIPTION
In lines 192, I solved the problem that expandOptions.parsed is overrided.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The expandVariables option is not working correctly when i create a dynamic module using ConfigModule.forRoot().
Because `parsed` in expandOptions is overrided.

Issue Number: N/A


## What is the new behavior?
`
config =
            expand({ ...expandOptions, parsed: config }).parsed || config;
`

to

```
config =
            expand({
              ...expandOptions,
              parsed: parsedInExpandOptions
                ? { ...parsedInExpandOptions, ...config }
                : config,
            }).parsed || config;
```


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
