### PR TITLE
feat: set or update environment variables dynamically (#1476)

### DIFF
--- a/tests/e2e/update-env.spec.ts
+++ b/tests/e2e/update-env.spec.ts
@@ -1,0 +1,75 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '../../lib';
+import { AppModule } from '../src/app.module';
+import { ConfigService } from '../../lib';
+
+describe('Setting environment variables', () => {
+  let app: INestApplication;
+  let module: TestingModule;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(async () => {
+    originalEnv = { ...process.env };
+
+    module = await Test.createTestingModule({
+      imports: [AppModule.withExpandedEnvVars()],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  it('should return updated value after set', async () => {
+    const prevUrl = module.get(ConfigService).get('URL');
+
+    module.get(ConfigService).set('URL', 'yourapp.test');
+
+    const updatedUrl = module.get(ConfigService).get('URL');
+
+    expect(prevUrl).toEqual('myapp.test');
+    expect(updatedUrl).toEqual('yourapp.test');
+  });
+
+  it('should return value after set', async () => {
+    const undefinedEnv = module.get(ConfigService).get('UNDEFINED_ENV');
+
+    module.get(ConfigService).set('UNDEFINED_ENV', 'defined');
+
+    const definedEnv = module.get(ConfigService).get('UNDEFINED_ENV');
+
+    expect(undefinedEnv).toEqual(undefined);
+    expect(definedEnv).toEqual('defined');
+  });
+
+  it('should return updated value with interpolation after set', async () => {
+    const prevUrl = module.get(ConfigService).get('URL');
+    const prevEmail = module.get(ConfigService).get('EMAIL');
+
+    module.get(ConfigService).set('URL', 'yourapp.test');
+
+    const updatedUrl = module.get(ConfigService).get('URL');
+    const updatedEmail = module.get(ConfigService).get('EMAIL');
+
+    expect(prevUrl).toEqual('myapp.test');
+    expect(prevEmail).toEqual('support@myapp.test');
+    expect(updatedUrl).toEqual('yourapp.test');
+    expect(updatedEmail).toEqual('support@yourapp.test');
+  });
+
+  it(`should return updated process.env property after set`, async () => {
+    await ConfigModule.envVariablesLoaded;
+
+    module.get(ConfigService).set('URL', 'yourapp.test');
+
+    const envVars = app.get(AppModule).getEnvVariables();
+
+    expect(envVars.URL).toEqual('yourapp.test');
+    expect(envVars.EMAIL).toEqual('support@yourapp.test');
+  });
+
+  afterEach(async () => {
+    process.env = originalEnv;
+    await app.close();
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently we can get environment variables and set cache. But there's no feature for setting environment variables dynamically. This could be useful even when testing the server locally so to make it dynamically updated when reloaded.

Issue Number: #1476 


## What is the new behavior?

This PR adds feature for setting/updating environment variables with the method `set` in `ConfigService`. And as `@nestjs/config` depends of `dotenv-expand` to resolve interpolation, I could get hint from **NOT being interpolated**. 

So after getting environment paths from module's config, simply can parse the environment variables as raw strings (I mean, like the option `expandVariables` to `false`). And then simply just replacing interpolated variables too.

This resolves #1476 

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
