### PR TITLE
feat(): add support for custom parsers

### DIFF
--- a/lib/interfaces/config-module-options.interface.ts
+++ b/lib/interfaces/config-module-options.interface.ts
@@ -1,5 +1,6 @@
 import { DotenvExpandOptions } from 'dotenv-expand';
 import { ConfigFactory } from './config-factory.interface';
+import { Parser } from '../types';
 
 /**
  * @publicApi
@@ -84,4 +85,9 @@ export interface ConfigModuleOptions<
    * this property is set to true.
    */
   expandVariables?: boolean | DotenvExpandOptions;
+
+  /**
+   * A function used to parse a buffer into a configuration object.
+   */
+  parser?: Parser;
 }

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -2,3 +2,4 @@ export * from './config-object.type';
 export * from './config.type';
 export * from './no-infer.type';
 export * from './path-value.type';
+export * from './parser.type';

--- a/lib/types/parser.type.ts
+++ b/lib/types/parser.type.ts
@@ -1,0 +1,1 @@
+export type Parser = (buffer: Buffer) => Record<string, any>;

--- a/lib/utils/get-default-parser.util.ts
+++ b/lib/utils/get-default-parser.util.ts
@@ -1,0 +1,4 @@
+import * as dotenv from 'dotenv';
+import { Parser } from '../types';
+
+export const getDefaultParser = (): Parser => dotenv.parse;

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './register-as.util';
 export * from './get-config-token.util';
+export * from './get-default-parser.util';

--- a/tests/e2e/.custom-config
+++ b/tests/e2e/.custom-config
@@ -1,0 +1,1 @@
+eyAibG9yZW0iOiAiaXBzdW0iIH0=

--- a/tests/e2e/custom-parser.spec.ts
+++ b/tests/e2e/custom-parser.spec.ts
@@ -1,0 +1,57 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { ConfigModule } from '../../lib';
+import { AppModule } from '../src/app.module';
+import { join } from 'path';
+
+describe('Custom parser', () => {
+  let app: INestApplication;
+
+  it(`should use dotenv parser by default`, async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppModule.withEnvVars()],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+    await ConfigModule.envVariablesLoaded;
+
+    const envVars = app.get(AppModule).getEnvVariables();
+    expect(envVars.PORT).toEqual('4000');
+  });
+
+  it(`should use custom parser when provided`, async () => {
+    const module = await Test.createTestingModule({
+      imports: [
+        {
+          module: AppModule,
+          imports: [
+            ConfigModule.forRoot({
+              envFilePath: join(
+                process.cwd(),
+                'tests',
+                'e2e',
+                '.custom-config',
+              ),
+              parser: buffer =>
+                JSON.parse(
+                  Buffer.from(buffer.toString('utf-8'), 'base64').toString(
+                    'utf-8',
+                  ),
+                ),
+            }),
+          ],
+        },
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+    const envVars = app.get(AppModule).getEnvVariables();
+    expect(envVars.lorem).toEqual('ipsum');
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});


### PR DESCRIPTION
This commit introduces a new configuration property named parser in ConfigModule, enabling the injection of custom parser functions. If not specified, the default implementation, backed by dotenv, is utilized.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

The dotenv parser cannot be replaced.
Issue Number: #1444 


## What is the new behavior?

The parser may be changed by a module consumer. If it's not, then the default implementation backed by dotenv is used.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
