### PR TITLE
Add test(@nestjs/config) for load priority

### DIFF
--- a/tests/e2e/load-priority.spec.ts
+++ b/tests/e2e/load-priority.spec.ts
@@ -64,6 +64,47 @@ describe('Environment variables and .env files', () => {
     });
   });
 
+  describe('with conflicts of .env file and loaded configuration', () => {
+    beforeAll(async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          AppModule.withEnvVarsAndLoadedConfigurations([
+            () => ({ PORT: '8000' }),
+          ]),
+        ],
+      }).compile();
+
+      app = moduleRef.createNestApplication();
+      await app.init();
+    });
+
+    it('should choose .env file vars over load configuration', () => {
+      const configService = app.get(ConfigService);
+      expect(configService.get('PORT')).toEqual('4000');
+    });
+  });
+
+  describe('with conflicts of multiple loaded configurations', () => {
+    beforeAll(async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          AppModule.withMultipleLoadedConfigurations([
+            () => ({ PORT: '8000' }),
+            () => ({ PORT: '9000' }),
+          ]),
+        ],
+      }).compile();
+
+      app = moduleRef.createNestApplication();
+      await app.init();
+    });
+
+    it('should choose last loaded configuration', () => {
+      const configService = app.get(ConfigService);
+      expect(configService.get('PORT')).toEqual('9000');
+    });
+  });
+
   afterEach(async () => {
     process.env = envBackup;
     await app.close();

--- a/tests/src/app.module.ts
+++ b/tests/src/app.module.ts
@@ -1,7 +1,7 @@
 import { DynamicModule, Inject, Module, Optional } from '@nestjs/common';
 import Joi from 'joi';
 import { join } from 'path';
-import { ConfigType } from '../../lib';
+import { ConfigFactory, ConfigType } from '../../lib';
 import { ConfigModule } from '../../lib/config.module';
 import { ConfigService } from '../../lib/config.service';
 import databaseConfig from './database.config';
@@ -98,7 +98,21 @@ export class AppModule {
       imports: [
         ConfigModule.forRoot({
           envFilePath: join(__dirname, '.env.expanded'),
-          expandVariables: { ignoreProcessEnv: true }
+          expandVariables: { ignoreProcessEnv: true },
+        }),
+      ],
+    };
+  }
+
+  static withEnvVarsAndLoadedConfigurations(
+    configFactory: ConfigFactory[],
+  ): DynamicModule {
+    return {
+      module: AppModule,
+      imports: [
+        ConfigModule.forRoot({
+          envFilePath: join(__dirname, '.env'),
+          load: configFactory,
         }),
       ],
     };
@@ -132,6 +146,19 @@ export class AppModule {
       imports: [
         ConfigModule.forRoot({
           load: [nestedDatabaseConfig],
+        }),
+      ],
+    };
+  }
+
+  static withMultipleLoadedConfigurations(
+    configFactory: ConfigFactory[],
+  ): DynamicModule {
+    return {
+      module: AppModule,
+      imports: [
+        ConfigModule.forRoot({
+          load: configFactory,
         }),
       ],
     };


### PR DESCRIPTION
I have a curiosity to see how config module works.
I think nestjs documents don't provide enough explanations.
If both .env file and load configration are provided, load configuration override .env vars?
If multiple load configrations are provided, last configuration take precedence?
That's why I add a couple of tests.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

N/A


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
