### PR TITLE
test(@nestjs/config) reset env correctly

### DIFF
--- a/tests/e2e/cache.spec.ts
+++ b/tests/e2e/cache.spec.ts
@@ -7,7 +7,9 @@ describe('Cache', () => {
   let app: INestApplication;
   let envBackup: NodeJS.ProcessEnv;
   beforeAll(() => {
-    envBackup = process.env;
+    envBackup = {
+      ...process.env,
+    };
   });
   describe('without cache', () => {
     beforeAll(async () => {
@@ -56,7 +58,9 @@ describe('Cache', () => {
   });
 
   afterEach(async () => {
-    process.env = envBackup;
+    process.env = {
+      ...envBackup,
+    };
     await app.close();
   });
 });

--- a/tests/e2e/load-priority.spec.ts
+++ b/tests/e2e/load-priority.spec.ts
@@ -8,7 +8,9 @@ describe('Environment variables and .env files', () => {
   let app: INestApplication;
   let envBackup: NodeJS.ProcessEnv;
   beforeAll(() => {
-    envBackup = process.env;
+    envBackup = {
+      ...process.env,
+    };
   });
   describe('without conflicts', () => {
     beforeAll(async () => {
@@ -65,7 +67,9 @@ describe('Environment variables and .env files', () => {
   });
 
   afterEach(async () => {
-    process.env = envBackup;
+    process.env = {
+      ...envBackup,
+    };
     await app.close();
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

I made a similar test file in config repo simply.

```
describe('Test Case', () => {
  let envBackup;
  beforeAll(() => {
    envBackup = process.env;
  });

  describe('Test Case 1', () => {
    it('run test 1', () => {
      process.env['a'] = "8000";
      expect(process.env.a).toBe("8000");
    });
  });

  describe('Test Case 2', () => {
    it('run test 2', () => {
      expect(process.env.a).toBe("8000");
    });
  });

  afterEach(() => {
    process.env = envBackup;
  });
});
```

In this case we expect `run test 2` to be failed. We guess the process.env will be reset in afterEach.
but it succeed.

Because `envBackup` variable is reference of `process.env`. If you change either `envBackup` or `process.env`, both of them will be updated. It doesn't be reset.
The first test case affects second test case. in second test case `process.env.a` is not undefined.

## What is the new behavior?

Fortunately test cases in config repo have developed independently. All test cases pass.
But I wanna remove a potential risk.
I changed they don't refer each other.
And I hope to add more test cases after merging. : )

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
