### PR TITLE
fix: close timeout in ConditionalModule

### DIFF
--- a/lib/conditional.module.ts
+++ b/lib/conditional.module.ts
@@ -13,14 +13,11 @@ export class ConditionalModule {
     condition: string | ((env: NodeJS.ProcessEnv) => boolean),
     options?: { timeout: number },
   ) {
-    let configResolved = false;
     const { timeout = 5000 } = options ?? {};
-    setTimeout(() => {
-      if (!configResolved) {
-        throw new Error(
-          `Nest was not able to resolve the config variables within ${timeout} milliseconds. Bause of this, the ConditionalModule was not able to determine if ${module.toString()} should be registered or not`,
-        );
-      }
+    const timer = setTimeout(() => {
+      throw new Error(
+        `Nest was not able to resolve the config variables within ${timeout} milliseconds. Bause of this, the ConditionalModule was not able to determine if ${module.toString()} should be registered or not`,
+      );
     }, timeout);
     const returnModule: Required<
       Pick<DynamicModule, 'module' | 'imports' | 'exports'>
@@ -32,7 +29,7 @@ export class ConditionalModule {
       };
     }
     await ConfigModule.envVariablesLoaded;
-    configResolved = true;
+    clearTimeout(timer);
     const evaluation = condition(process.env);
     if (evaluation) {
       returnModule.imports.push(module);


### PR DESCRIPTION
When conditional module was used in integration
tests with jest, then an open handle would be
reported due to setTimeout promise not triggering
before the tests execution finishes.
To avoid open handles close the timeout instead of setting a boolean variable and checking its value
after 5 (by default) seconds.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Timeout is set when `ConditionalModule.registerWhen` is executed, but it is never stopped. Instead a boolean variable is used to avoid throwing an error when it is not necessary. This timeout is not always triggered during tests execution which leads to a problem with an open handle.

Issue Number: N/A


## What is the new behavior?
Nothing changes in terms of method execution, but instead of using a boolean variable to avoid throwing an error timeout is cleared to achieve the same result.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

## Other information
