### PR TITLE
feat: ability to disable debug message in ConditionalModule

### DIFF
--- a/lib/conditional.module.ts
+++ b/lib/conditional.module.ts
@@ -11,9 +11,9 @@ export class ConditionalModule {
   static async registerWhen(
     module: Required<ModuleMetadata>['imports'][number],
     condition: string | ((env: NodeJS.ProcessEnv) => boolean),
-    options?: { timeout: number },
+    options?: { timeout?: number; debug?: boolean },
   ) {
-    const { timeout = 5000 } = options ?? {};
+    const { timeout = 5000, debug = true } = options ?? {};
 
     const timer = setTimeout(() => {
       throw new Error(
@@ -38,10 +38,12 @@ export class ConditionalModule {
       returnModule.imports.push(module);
       returnModule.exports.push(module);
     } else {
-      Logger.debug(
-        `${condition.toString()} evaluated to false. Skipping the registration of ${module.toString()}`,
-        ConditionalModule.name,
-      );
+      if (debug) {
+        Logger.debug(
+          `${condition.toString()} evaluated to false. Skipping the registration of ${module.toString()}`,
+          ConditionalModule.name,
+        );
+      }
     }
     return returnModule;
   }


### PR DESCRIPTION
Add an option `debug` defaulted to true to the `registerWhen` method and only create debug log when it is set to true. Also adjust the type for options.timeout to be optional.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently a ConditionalModule is run when a javascript module is loaded but before any NestJS setup occurs.  The ConditionalModule.  In this case, the module will output a debug log via the default ConsoleLogger with no ability to silence the message.

Issue Number: N/A


## What is the new behavior?

Add an option to the ConditionalModule's registerWhen method to disable the debug message.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The debug flag is defaulted to true so that no change will be observed, however the timeout option is being flagged as optional so previous code that would have shown a type error with an empty object will now pass.