### PR TITLE
feat: add glob pattern matching for env files

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "dotenv": "16.4.5",
     "dotenv-expand": "10.0.0",
+    "glob": "^11.0.0",
     "lodash": "4.17.21"
   },
   "devDependencies": {

--- a/tests/e2e/load-glob-match-env.spec.ts
+++ b/tests/e2e/load-glob-match-env.spec.ts
@@ -1,0 +1,26 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { AppModule } from '../src/app.module';
+
+describe('Environment variables (glob match env files)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppModule.withGlobMatchEnvFiles()],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  it(`should return loaded env variables`, () => {
+    const envVars = app.get(AppModule).getEnvVariables();
+    expect(envVars.PORT).toEqual('3000');
+    expect(envVars.TIMEOUT).toEqual('5000');
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});

--- a/tests/src/app.module.ts
+++ b/tests/src/app.module.ts
@@ -129,6 +129,17 @@ export class AppModule {
     };
   }
 
+  static withGlobMatchEnvFiles(): DynamicModule {
+    return {
+      module: AppModule,
+      imports: [
+        ConfigModule.forRoot({
+          envFilePath: join(__dirname, '.env*'),
+        }),
+      ],
+    };
+  }
+
   static withLoadedConfigurations(): DynamicModule {
     return {
       module: AppModule,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

The envFilePath only supports matching specific paths, which becomes cumbersome when trying to match multiple paths.

Issue Number: N/A


## What is the new behavior?
Use glob pattern matching for paths. For example:
`envFilePath: ".env*"` can match .env, .env.local, .env.production, etc.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
