### PR TITLE
feat: allow to use symbol as a token

### DIFF
--- a/lib/config.service.ts
+++ b/lib/config.service.ts
@@ -43,7 +43,7 @@ type KeyOf<T> = keyof T extends never ? string : keyof T;
  */
 @Injectable()
 export class ConfigService<
-  K = Record<string, unknown>,
+  K = Record<string | symbol, unknown>,
   WasValidated extends boolean = false,
 > {
   private set isCacheEnabled(value: boolean) {
@@ -72,7 +72,7 @@ export class ConfigService<
     @Optional()
     @Inject(CONFIGURATION_TOKEN)
     private readonly internalConfig: Record<string, any> = {},
-  ) {}
+  ) { }
 
   /**
    * Returns a stream of configuration changes.
@@ -142,7 +142,7 @@ export class ConfigService<
     }
     const defaultValue =
       this.isGetOptionsObject(defaultValueOrOptions as Record<string, any>) &&
-      !options
+        !options
         ? undefined
         : defaultValueOrOptions;
 

--- a/lib/utils/get-config-token.util.ts
+++ b/lib/utils/get-config-token.util.ts
@@ -1,6 +1,6 @@
 /**
  * @publicApi
  */
-export function getConfigToken(token: string): string {
-  return `CONFIGURATION(${token})`;
+export function getConfigToken(token: string | symbol): string {
+  return `CONFIGURATION(${token.toString()})`;
 }

--- a/lib/utils/register-as.util.ts
+++ b/lib/utils/register-as.util.ts
@@ -12,11 +12,11 @@ import { getConfigToken } from './get-config-token.util';
  * @publicApi
  */
 export interface ConfigFactoryKeyHost<T = unknown> {
-  KEY: string;
+  KEY: string | symbol;
   asProvider(): {
     imports: [ReturnType<typeof ConfigModule.forFeature>];
     useFactory: (config: T) => T;
-    inject: [string];
+    inject: [string | symbol];
   };
 }
 
@@ -29,7 +29,7 @@ export function registerAs<
   TConfig extends ConfigObject,
   TFactory extends ConfigFactory = ConfigFactory<TConfig>,
 >(
-  token: string,
+  token: string | symbol,
   configFactory: TFactory,
 ): TFactory & ConfigFactoryKeyHost<ReturnType<TFactory>> {
   const defineProperty = (key: string, value: unknown) => {

--- a/tests/e2e/load-symbol-files.spec.ts
+++ b/tests/e2e/load-symbol-files.spec.ts
@@ -1,0 +1,26 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { AppModule } from '../src/app.module';
+
+describe('Symbol Files', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppModule.withSymbolLoadedConfigurations()],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  it(`should return symbol loaded configuration`, () => {
+    const config = app.get(AppModule).getSymbolDatabaseConfig();
+    expect(config.host).toEqual('host');
+    expect(config.port).toEqual(4000);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});

--- a/tests/src/app.module.ts
+++ b/tests/src/app.module.ts
@@ -6,6 +6,7 @@ import { ConfigModule } from '../../lib/config.module';
 import { ConfigService } from '../../lib/config.service';
 import databaseConfig from './database.config';
 import nestedDatabaseConfig from './nested-database.config';
+import symbolDatabaseConfig, { DATABASE_SYMBOL_TOKEN } from './symbol-database.config';
 
 type Config = {
   database: ConfigType<typeof databaseConfig> & {
@@ -31,7 +32,7 @@ export class AppModule {
     @Optional()
     @Inject(databaseConfig.KEY)
     private readonly dbConfig: ConfigType<typeof databaseConfig>,
-  ) {}
+  ) { }
 
   /**
    * This method is not meant to be used anywhere! It just here for testing
@@ -175,6 +176,17 @@ export class AppModule {
     };
   }
 
+  static withSymbolLoadedConfigurations(): DynamicModule {
+    return {
+      module: AppModule,
+      imports: [
+        ConfigModule.forRoot({
+          load: [symbolDatabaseConfig],
+        }),
+      ],
+    };
+  }
+
   static withDynamicLoadedConfigurations(
     configFactory: ConfigFactory[],
   ): DynamicModule {
@@ -248,5 +260,9 @@ export class AppModule {
 
   getNestedDatabaseHost() {
     return this.configService.get('database.driver.host');
+  }
+
+  getSymbolDatabaseConfig() {
+    return this.configService.get(DATABASE_SYMBOL_TOKEN)
   }
 }

--- a/tests/src/symbol-database.config.ts
+++ b/tests/src/symbol-database.config.ts
@@ -1,0 +1,8 @@
+import { registerAs } from '../../lib/utils';
+
+export const DATABASE_SYMBOL_TOKEN = Symbol('database');
+
+export default registerAs(DATABASE_SYMBOL_TOKEN, () => ({
+  host: 'host',
+  port: 4000,
+}));


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, we can only use strings as tokens to register configs. Sometimes, this may lead to collisions and potential errors if we override a config with the same key. Using symbols as tokens would ensure that we never cause collisions with other configs.

Issue Number: N/A


## What is the new behavior?

We can use symbol as a token to register config.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Wdyt?