### PR TITLE
fix(common): update KeyOf type to support symbol keys

### DIFF
--- a/lib/config.service.ts
+++ b/lib/config.service.ts
@@ -36,7 +36,7 @@ export interface ConfigGetOptions {
   infer: true;
 }
 
-type KeyOf<T> = keyof T extends never ? string : keyof T;
+type KeyOf<T> = keyof T extends never ? string | symbol : keyof T;
 
 /**
  * @publicApi


### PR DESCRIPTION
This change extends the KeyOf type to support symbol keys when keyof T extends never. This allows the config service to properly handle configurations that use symbols as keys.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
TypeScript error when using symbol as key in `ConfigService.get()` or `ConfigService.getOrThrow()`  inside main.ts
```
Argument of type 'SYMBOL_KEY' is not assignable to parameter of type 'string'.
```

Issue Number: #1996


## What is the new behavior?
Symbol keys work directly without casting, providing proper type safety.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
None...
