### PR TITLE
fix(type): config service get and getOrThrow methods return type

### DIFF
--- a/lib/config.service.ts
+++ b/lib/config.service.ts
@@ -94,7 +94,11 @@ export class ConfigService<
    * @param propertyPath
    * @param options
    */
-  get<T = K, P extends Path<T> = any, R = PathValue<T, P>>(
+  get<
+    T = K,
+    P extends Path<T> = any,
+    R extends PathValue<T, P> = PathValue<T, P>,
+  >(
     propertyPath: P,
     options: ConfigGetOptions,
   ): ValidatedResult<WasValidated, R>;
@@ -114,7 +118,11 @@ export class ConfigService<
    * @param defaultValue
    * @param options
    */
-  get<T = K, P extends Path<T> = any, R = PathValue<T, P>>(
+  get<
+    T = K,
+    P extends Path<T> = any,
+    R extends PathValue<T, P> = PathValue<T, P>,
+  >(
     propertyPath: P,
     defaultValue: NoInferType<R>,
     options: ConfigGetOptions,
@@ -171,10 +179,11 @@ export class ConfigService<
    * @param propertyPath
    * @param options
    */
-  getOrThrow<T = K, P extends Path<T> = any, R = PathValue<T, P>>(
-    propertyPath: P,
-    options: ConfigGetOptions,
-  ): Exclude<R, undefined>;
+  getOrThrow<
+    T = K,
+    P extends Path<T> = any,
+    R extends PathValue<T, P> = PathValue<T, P>,
+  >(propertyPath: P, options: ConfigGetOptions): Exclude<R, undefined>;
   /**
    * Get a configuration value (either custom configuration or process environment variable)
    * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").
@@ -196,7 +205,11 @@ export class ConfigService<
    * @param defaultValue
    * @param options
    */
-  getOrThrow<T = K, P extends Path<T> = any, R = PathValue<T, P>>(
+  getOrThrow<
+    T = K,
+    P extends Path<T> = any,
+    R extends PathValue<T, P> = PathValue<T, P>,
+  >(
     propertyPath: P,
     defaultValue: NoInferType<R>,
     options: ConfigGetOptions,

--- a/tests/e2e/optional-generic.spec.ts
+++ b/tests/e2e/optional-generic.spec.ts
@@ -69,6 +69,34 @@ describe('Optional Generic()', () => {
     expect(port).toEqual('default');
   });
 
+  it(`should compile error when return wrong type`, () => {
+    const configService =
+      moduleRef.get<ConfigService<{ PORT: string }>>(ConfigService);
+
+    // @ts-expect-error: PORT is a string, not a number. Should throw an error
+    const port: number | undefined = configService.get('PORT', { infer: true });
+
+    // @ts-expect-error: PORT is a string, not a number. Should throw an error
+    const portWithDefaultValue: number = configService.get('PORT', '', {
+      infer: true,
+    });
+  });
+
+  it(`should compile error when return wrong type (getOrThrow)`, () => {
+    const configService =
+      moduleRef.get<ConfigService<{ PORT: string }>>(ConfigService);
+
+    // @ts-expect-error: PORT is a string, not a number. Should throw an error
+    const port: number = configService.getOrThrow('PORT', {
+      infer: true,
+    });
+
+    // @ts-expect-error: PORT is a string, not a number. Should throw an error
+    const portWithDefaultValue: number = configService.getOrThrow('PORT', '', {
+      infer: true,
+    });
+  });
+
   afterEach(async () => {
     await app.close();
   });


### PR DESCRIPTION
When a ConfigService type is provided, the return type should match the given type; otherwise, a compile error should occur.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

When the type of receiver variable and the type provided by ConfigService don't match, no error occurs.

## What is the new behavior?
When a ConfigService type is provided, a typescript compile error will occur if return type and given type doesn't match.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
If a variable type has previously provided but doesn't match the return type provided in ConfigService, typescript will produce a compile error and `// @ts-ignore` is required to ignore error.

## Other information
