### PR TITLE
fix(common): emit type errors for optional fields when WasValidated is true

### DIFF
--- a/lib/config.service.ts
+++ b/lib/config.service.ts
@@ -94,10 +94,10 @@ export class ConfigService<
    * @param propertyPath
    * @param options
    */
-  get<T = K, P extends Path<T> = any, R = PathValue<T, P>>(
+  get<T = K, P extends Path<T> = any>(
     propertyPath: P,
     options: ConfigGetOptions,
-  ): ValidatedResult<WasValidated, R>;
+  ): ValidatedResult<WasValidated, PathValue<T, P>>;
   /**
    * Get a configuration value (either custom configuration or process environment variable)
    * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").
@@ -114,11 +114,11 @@ export class ConfigService<
    * @param defaultValue
    * @param options
    */
-  get<T = K, P extends Path<T> = any, R = PathValue<T, P>>(
+  get<T = K, P extends Path<T> = any>(
     propertyPath: P,
-    defaultValue: NoInferType<R>,
+    defaultValue: NoInferType<PathValue<T, P>>,
     options: ConfigGetOptions,
-  ): Exclude<R, undefined>;
+  ): Exclude<PathValue<T, P>, undefined>;
   /**
    * Get a configuration value (either custom configuration or process environment variable)
    * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").
@@ -171,10 +171,10 @@ export class ConfigService<
    * @param propertyPath
    * @param options
    */
-  getOrThrow<T = K, P extends Path<T> = any, R = PathValue<T, P>>(
+  getOrThrow<T = K, P extends Path<T> = any>(
     propertyPath: P,
     options: ConfigGetOptions,
-  ): Exclude<R, undefined>;
+  ): Exclude<PathValue<T, P>, undefined>;
   /**
    * Get a configuration value (either custom configuration or process environment variable)
    * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").
@@ -196,11 +196,11 @@ export class ConfigService<
    * @param defaultValue
    * @param options
    */
-  getOrThrow<T = K, P extends Path<T> = any, R = PathValue<T, P>>(
+  getOrThrow<T = K, P extends Path<T> = any>(
     propertyPath: P,
-    defaultValue: NoInferType<R>,
+    defaultValue: NoInferType<PathValue<T, P>>,
     options: ConfigGetOptions,
-  ): Exclude<R, undefined>;
+  ): Exclude<PathValue<T, P>, undefined>;
   /**
    * Get a configuration value (either custom configuration or process environment variable)
    * based on property path (you can use dot notation to traverse nested object, e.g. "database.host").

--- a/tests/e2e/type-inference-validated.spec.ts
+++ b/tests/e2e/type-inference-validated.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * Type tests for ConfigService with WasValidated parameter
+ * Verifies fix for issue #2182: TypeScript type checking inconsistency with optional fields
+ *
+ * These tests use @ts-expect-error to verify that TypeScript correctly
+ * detects type errors when assigning potentially undefined values to strict types.
+ */
+import { ConfigService } from '../../lib';
+
+// Simulates a Zod schema with optional field: z.object({ KEY: z.string().optional() })
+type ConfigWithOptional = {
+  OPTIONAL_KEY: string | undefined;
+  REQUIRED_KEY: string;
+};
+
+describe('Type inference with WasValidated parameter', () => {
+  // These tests verify compile-time behavior using @ts-expect-error
+  // If the types are wrong, the @ts-expect-error comments will cause compilation to fail
+
+  describe('ConfigService<Config, true> (validated)', () => {
+    let configService: ConfigService<ConfigWithOptional, true>;
+
+    beforeEach(() => {
+      // Mock the config service for runtime tests
+      configService = {
+        get: jest.fn().mockReturnValue('test-value'),
+        getOrThrow: jest.fn().mockReturnValue('test-value'),
+      } as unknown as ConfigService<ConfigWithOptional, true>;
+    });
+
+    it('should correctly type optional fields as string | undefined', () => {
+      const value = configService.get('OPTIONAL_KEY', { infer: true });
+
+      // Runtime test
+      expect(value).toBeDefined();
+
+      // Type test: value should be string | undefined, so this should work
+      const _acceptsUndefined: string | undefined = value;
+
+      // Type test: assigning to strict string should error
+      // @ts-expect-error Type 'string | undefined' is not assignable to type 'string'
+      const _strictString: string = value;
+    });
+
+    it('should correctly type required fields as string', () => {
+      const value = configService.get('REQUIRED_KEY', { infer: true });
+
+      // Runtime test
+      expect(value).toBeDefined();
+
+      // Type test: value should be string, so this should work
+      const _strictString: string = value;
+    });
+
+    it('should return non-undefined type when default value is provided', () => {
+      const value = configService.get('OPTIONAL_KEY', 'default', { infer: true });
+
+      // Runtime test
+      expect(value).toBeDefined();
+
+      // Type test: with default value, result should be string (no undefined)
+      const _strictString: string = value;
+    });
+
+    it('should correctly type getOrThrow as excluding undefined', () => {
+      const value = configService.getOrThrow('OPTIONAL_KEY', { infer: true });
+
+      // Runtime test
+      expect(value).toBeDefined();
+
+      // Type test: getOrThrow should exclude undefined from return type
+      const _strictString: string = value;
+    });
+  });
+
+  describe('ConfigService<Config, false> (not validated)', () => {
+    let configService: ConfigService<ConfigWithOptional, false>;
+
+    beforeEach(() => {
+      configService = {
+        get: jest.fn().mockReturnValue('test-value'),
+        getOrThrow: jest.fn().mockReturnValue('test-value'),
+      } as unknown as ConfigService<ConfigWithOptional, false>;
+    });
+
+    it('should add undefined to all types when not validated', () => {
+      const optionalValue = configService.get('OPTIONAL_KEY', { infer: true });
+      const requiredValue = configService.get('REQUIRED_KEY', { infer: true });
+
+      // Runtime test
+      expect(optionalValue).toBeDefined();
+      expect(requiredValue).toBeDefined();
+
+      // Type test: both should include undefined when WasValidated is false
+      // @ts-expect-error Type 'string | undefined' is not assignable to type 'string'
+      const _strictOptional: string = optionalValue;
+
+      // @ts-expect-error Type 'string | undefined' is not assignable to type 'string'
+      const _strictRequired: string = requiredValue;
+    });
+  });
+});
+


### PR DESCRIPTION

Closes #2182

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When using `ConfigService<Config, true>` with a configuration type that includes optional fields (e.g., from Zod's `.optional()`), TypeScript does not emit type errors when assigning `string | undefined` to a strict `string` type.

This happens because the `R` type parameter in the `get`/`getOrThrow` overloads is inferred from contextual typing (the expected return type) instead of using the default `PathValue<T, P>`.

Example:

```
type Config = { API_KEY: string | undefined };

class Service {
  private apiKey: string;
  constructor(private config: ConfigService<Config, true>) {
    // Should error but doesn't!
    this.apiKey = this.config.get('API_KEY', { infer: true });
  }
}

```
Issue Number: #2182

## What is the new behavior?

TypeScript now correctly emits type errors when assigning potentially undefined values to strict types, regardless of the `WasValidated` parameter.

The fix removes the `R` type parameter from the affected overloads and uses `PathValue<T, P>` directly in the return type, preventing contextual typing from overriding the correct type inference.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

The fix is compile-time only and does not change runtime behavior. Code that previously compiled without errors but was incorrectly typed will now show appropriate type errors, which is the expected/correct behavior.

## Other information


Affected method overloads:
- `get(propertyPath, options)` 
- `get(propertyPath, defaultValue, options)`
- `getOrThrow(propertyPath, options)`
- `getOrThrow(propertyPath, defaultValue, options)`

Added test file `tests/e2e/type-inference-validated.spec.ts` that uses `@ts-expect-error` to verify correct type inference behavior for both `WasValidated = true` and `WasValidated = false` cases
