### PR TITLE
feat(config): add override option to ConfigModule

### DIFF
--- a/lib/interfaces/config-module-options.interface.ts
+++ b/lib/interfaces/config-module-options.interface.ts
@@ -84,4 +84,10 @@ export interface ConfigModuleOptions<
    * this property is set to true.
    */
   expandVariables?: boolean | DotenvExpandOptions;
+
+  /**
+   * If "true", existing environment variables will be overridden by values from the .env file.
+   * @default false
+   */
+  override?: boolean;
 }

--- a/tests/e2e/override-env.spec.ts
+++ b/tests/e2e/override-env.spec.ts
@@ -1,0 +1,56 @@
+import { join } from "path"
+import * as fs from 'fs';
+import { Test } from "@nestjs/testing";
+import { ConfigModule } from "../../lib";
+
+
+describe('Environment variables override', () => {
+    const envFilePath = join(__dirname, '.env.override-test');
+
+    beforeAll(() => {
+        // Create a temporary .env file for test
+        fs.writeFileSync(envFilePath, 'EXISTING_VAR=new_value');
+    });
+
+    afterAll(() => {
+        // Clean up the temporary .env file
+        if (fs.existsSync(envFilePath)) {
+            fs.unlinkSync(envFilePath);
+        }
+    });
+
+    it('should NOT override process.env when "override" is false', async () => {
+        process.env.EXISTING_VAR = 'original_value';
+
+        // Load the config module with override set to false
+        await Test.createTestingModule({
+            imports: [
+                ConfigModule.forRoot({
+                    envFilePath: envFilePath,
+                    override: false,
+                }),
+            ],
+        }).compile();
+
+        expect(process.env.EXISTING_VAR).toBe('original_value');
+        delete process.env.EXISTING_VAR;
+    });
+
+    it('should override process.env when "override" is true', async () => {
+        process.env.EXISTING_VAR = 'original_value';
+        
+        // Load the config module with override set to true
+        await Test.createTestingModule({
+            imports: [
+                ConfigModule.forRoot({
+                    envFilePath: envFilePath,
+                    override: true,
+                }),
+            ],
+        }).compile();
+
+        expect(process.env.EXISTING_VAR).toBe('new_value');
+        delete process.env.EXISTING_VAR;
+    });
+
+})


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, @nestjs/config does not allow environment variables in a .env file to override variables already defined in process.env. This is because the internal merging logic prioritizes process.env and filters out existing keys during the assignment phase.

Issue Number: #2261


## What is the new behavior?
This PR introduces an override property to ConfigModuleOptions. When set to true:

1. The internal config object will prioritize values from the .env file over process.env.

2. The `assignVariablesToProcess` method will overwrite existing keys in process.env with the values from the loaded configuration.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


## Other information
I have added an E2E test suite in tests/e2e/override-env.spec.ts to verify both the override functionality and the preservation of the default behavior.